### PR TITLE
Fix args parsing: dots in unquoted strings and fix removed quotes inside quoted string

### DIFF
--- a/nubia/internal/parser.py
+++ b/nubia/internal/parser.py
@@ -65,7 +65,7 @@ unquoted_string = pp.Word(pp.alphanums + allowed_symbols_in_string).setParseActi
 
 string_value = quoted_string | unquoted_string
 
-single_value = bool_value | float_value | string_value | int_value
+single_value = bool_value | string_value | float_value | int_value
 
 list_value = pp.Group(
     pp.Suppress("[") + pp.Optional(pp.delimitedList(single_value)) + pp.Suppress("]")

--- a/nubia/internal/parser.py
+++ b/nubia/internal/parser.py
@@ -23,7 +23,9 @@ def _bool_transform(x):
 
 
 def _str_transform(x):
-    return x.strip("\"'")
+    if x and ((x[0] == x[-1] == '"') or (x[0] == x[-1] == '"')):
+        return x[1:-1]
+    return x
 
 
 _TRANSFORMS = {

--- a/nubia/internal/parser.py
+++ b/nubia/internal/parser.py
@@ -23,7 +23,7 @@ def _bool_transform(x):
 
 
 def _str_transform(x):
-    if x and ((x[0] == x[-1] == '"') or (x[0] == x[-1] == '"')):
+    if x and ((x[0] == x[-1] == '"') or (x[0] == x[-1] == "'")):
         return x[1:-1]
     return x
 


### PR DESCRIPTION
This PR fixes some issues in argument parsing:
- When an unquoted  string has dots, a parsing error was raised
- If a quoted string contains quotes inside, the quotes at the end and at the beginning was stripped too (i.e. `arg="something='else'"` became `something='else`