### PR TITLE
Limit completions offered when completions are too many

### DIFF
--- a/nubia/internal/completion.py
+++ b/nubia/internal/completion.py
@@ -54,6 +54,7 @@ class TokenParse:
             assert len(value) == 0
         if len(value) > 0:
             # Let's parse the value, is it a single, list, dict?
+            value = value.strip()
             if value[0] == "[":
                 self._is_list = True
                 value = value.strip("[")

--- a/nubia/internal/completion.py
+++ b/nubia/internal/completion.py
@@ -236,19 +236,31 @@ class AutoCommandCompletion:
                 choices = arg.choices(
                     self.cmd.metadata.command.name, subcommand, last_token,
                     self.doc.text)
-                if not isinstance(choices , List):
+                if not isinstance(choices, List):
                     raise ValueError('autocomplete function MUST provide list of strings'
                                      f', got {choices}')
             else:
                 choices = arg.choices
 
-            return [
-                Completion(
-                    text=str(choice),
-                    start_position=-len(parsed_token.last_value),
-                )
-                for choice in choices
-            ]
+            if len(choices) > 10:
+                # Avoid creating slowness or problems when there are too many
+                # choices. Show just the first 10, but the rest are still
+                # available.
+                return [
+                    Completion(
+                        text=str(choice),
+                        start_position=-len(parsed_token.last_value),
+                    )
+                    for choice in choices[:11]
+                ]
+            else:
+                return [
+                    Completion(
+                        text=str(choice),
+                        start_position=-len(parsed_token.last_value),
+                    )
+                    for choice in choices
+                ]
 
         # We are completing arguments, or positionals.
         # TODO: We would like to only show positional choices if we exhaust all

--- a/nubia/internal/completion.py
+++ b/nubia/internal/completion.py
@@ -213,6 +213,7 @@ class AutoCommandCompletion:
         # Dissect the last_token and figure what is the right completion
         parsed_token = TokenParse(last_token)
 
+        ret = []
         if parsed_token.is_positional:
             # TODO: Handle positional argument completions too
             # To figure which positional we are in right now, we need to run the
@@ -242,25 +243,14 @@ class AutoCommandCompletion:
             else:
                 choices = arg.choices
 
-            if len(choices) > 10:
-                # Avoid creating slowness or problems when there are too many
-                # choices. Show just the first 10, but the rest are still
-                # available.
-                return [
-                    Completion(
-                        text=str(choice),
-                        start_position=-len(parsed_token.last_value),
-                    )
-                    for choice in choices[:11]
-                ]
-            else:
-                return [
-                    Completion(
-                        text=str(choice),
-                        start_position=-len(parsed_token.last_value),
-                    )
-                    for choice in choices
-                ]
+            ret = [
+                Completion(
+                    text=str(choice),
+                    start_position=-len(parsed_token.last_value),
+                )
+                for choice in choices[:self.cmd._options.limit_visible_choices]
+            ]
+            return ret
 
         # We are completing arguments, or positionals.
         # TODO: We would like to only show positional choices if we exhaust all

--- a/nubia/internal/completion.py
+++ b/nubia/internal/completion.py
@@ -242,7 +242,11 @@ class AutoCommandCompletion:
                     raise ValueError('autocomplete function MUST provide list of strings'
                                      f', got {choices}')
             else:
-                choices = arg.choices
+                if parsed_token.last_value:
+                    choices = [c for c in arg.choices
+                               if str(c).startswith(parsed_token.last_value)]
+                else:
+                    choices = arg.choices
 
             ret = [
                 Completion(

--- a/nubia/internal/options.py
+++ b/nubia/internal/options.py
@@ -29,3 +29,8 @@ class Options:
     #    suggestions
     # If this is set to false it just prints the suggestions
     auto_execute_single_suggestions: bool = True
+
+    # Limit the choices displayed to this number. All choices are available, just
+    # what is displayed is limited to this number to avoid having the user scroll down
+    # a long list.
+    limit_visible_choices: int = 10


### PR DESCRIPTION
In case the number of completions is too many, say the list of hostnames in a 10000 node network, instead of trying to show all 10K hostnames as completions, do it only for the first ten. But the entire list exists, and so you can still start typing to get completions for the ones not listed yet.

Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>