### PR TITLE
Fix typing check

### DIFF
--- a/nubia/internal/typing/builder.py
+++ b/nubia/internal/typing/builder.py
@@ -154,6 +154,11 @@ def _apply_dict_type(value, key_type=None, value_type=None):
     if not key_type and not value_type:
         return dict(value)
 
+    if not isinstance(value, dict):
+        raise ValueError(
+            "Cannot convert {} to dictionary".format(value)
+        )
+
     key_type = key_type or _identity_function
     value_type = value_type or _identity_function
     return {key_type(key): value_type(value) for key, value in value.items()}

--- a/nubia/internal/typing/inspect.py
+++ b/nubia/internal/typing/inspect.py
@@ -17,11 +17,18 @@ from typing_inspect import NEW_TYPING, is_tuple_type, is_typevar, is_union_type
 from nubia.internal.helpers import issubclass_
 
 if NEW_TYPING:
-    from typing import _GenericAlias
+    # from python 3.9 List, Dict are _SpecialGenericAlias type, which with
+    # _GenericAlias is subclass of _BaseGenericAlias
+    try:
+        from typing import _BaseGenericAlias
+        GENERIC_TYPE = _BaseGenericAlias
+    except ImportError:
+        from typing import _GenericAlias
+        GENERIC_TYPE = _GenericAlias
 
 
 def _is_generic_alias_of(this, that) -> bool:
-    return isinstance(this, _GenericAlias) and issubclass_(this.__origin__, that)
+    return isinstance(this, GENERIC_TYPE) and issubclass_(this.__origin__, that)
 
 
 def is_none_type(tp) -> bool:
@@ -39,7 +46,7 @@ def is_mapping_type(tp) -> bool:
 def is_iterable_type(tp) -> bool:
     """Checks whether a type is an iterable type."""
     if NEW_TYPING:
-        return tp is Iterable or tp is List or _is_generic_alias_of(tp, collections.abc.Iterable)
+        return tp is Iterable or _is_generic_alias_of(tp, collections.abc.Iterable)
     return issubclass_(tp, list)
 
 


### PR DESCRIPTION
This PR fixes some typing check issues:
- With Python 3.9 changed the structured of the typing class, so that some aliases are not subclass of `_GenericAlias` but of `_SpecialGenericAlias`. Because of this changes Nubia wasn't able to detect types like List or Dict. This PR fixes this issue keeping the backward compatibility
- Fix crash when it's not possible to convert an argument to the dict type